### PR TITLE
Fix board state to observation tensor bug

### DIFF
--- a/src/training/input.py
+++ b/src/training/input.py
@@ -23,7 +23,7 @@ def convert_state_to_array_for_player(
             for row in state.grid
             for tile in row
         ]
-    ).reshape(-1, state.num_rows, state.num_cols)
+    ).reshape(state.num_rows, state.num_cols, -1).transpose(2, 0, 1)
     return state_array
 
 


### PR DESCRIPTION
Before:

<img width="934" alt="image" src="https://github.com/user-attachments/assets/a4418d9d-18f8-4b0b-94f8-c3b1482dcbfb">
<img width="76" alt="image" src="https://github.com/user-attachments/assets/66339d48-7ad1-4c1a-92e2-6c5b9a74caa6">

Note that the `obs_tensor` refers to the next observation, which is shown in the second picture above.

Notice how the `obs_tensor` (printed here in `channels_last` format for readability) doesn't match up with the encoding scheme described in `input.py`. This is because a call to `.reshape(-1, num_rows, num_cols)` should instead be a `transpose` call to transform the board tensor from `channels_last` to `channels_first`.

After fix:

<img width="943" alt="image" src="https://github.com/user-attachments/assets/88fd30bc-9170-4b1e-8627-81a3f5f962ad">
<img width="74" alt="image" src="https://github.com/user-attachments/assets/530bae60-1f18-428b-8159-3e3664d10132">

Much better!
